### PR TITLE
Define CQS contracts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: csharp
+mono: none
+sudo: required
+dist: xenial
+dotnet: 2.2
+
+script:
+ - cd src
+ - dotnet restore
+ - dotnet build -c Release

--- a/src/Functional.CQS.sln
+++ b/src/Functional.CQS.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Functional.CQS", "Functional.CQS\Functional.CQS.csproj", "{7C8AA96C-DEDB-48A3-95F0-7855C26C8E83}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7C8AA96C-DEDB-48A3-95F0-7855C26C8E83}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7C8AA96C-DEDB-48A3-95F0-7855C26C8E83}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7C8AA96C-DEDB-48A3-95F0-7855C26C8E83}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7C8AA96C-DEDB-48A3-95F0-7855C26C8E83}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3CCA6DAD-E6D2-4199-8295-0BBE8BF4E862}
+	EndGlobalSection
+EndGlobal

--- a/src/Functional.CQS/Functional.CQS.csproj
+++ b/src/Functional.CQS/Functional.CQS.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DocumentationFile>D:\Projects\Functional.CQS\src\Functional.CQS\Functional.CQS.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DocumentationFile>D:\Projects\Functional.CQS\src\Functional.CQS\Functional.CQS.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="IQueryHandler.cs~RF17d4a98.TMP" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Functional.CQS/Functional.CQS.csproj
+++ b/src/Functional.CQS/Functional.CQS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -11,10 +11,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>D:\Projects\Functional.CQS\src\Functional.CQS\Functional.CQS.xml</DocumentationFile>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="IQueryHandler.cs~RF17d4a98.TMP" />
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Functional.Primitives" Version="1.9.0" />

--- a/src/Functional.CQS/Functional.CQS.xml
+++ b/src/Functional.CQS/Functional.CQS.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Functional.CQS</name>
+    </assembly>
+    <members>
+        <member name="T:Functional.CQS.IAsyncCommandHandler`2">
+            <summary>
+            Interface for asynchronous command handlers.
+            </summary>
+            <typeparam name="TCommand">The command type.</typeparam>
+            <typeparam name="TError">The error type.</typeparam>
+        </member>
+        <member name="M:Functional.CQS.IAsyncCommandHandler`2.HandleAsync(`0,System.Threading.CancellationToken)">
+            <summary>
+            Execute the command.
+            </summary>
+            <param name="parameters">The command parameters.</param>
+            <param name="cancellationToken">The cancellation token.</param>
+            <returns></returns>
+        </member>
+        <member name="T:Functional.CQS.IAsyncQueryHandler`2">
+            <summary>
+            Interface for asynchronous query handlers.
+            </summary>
+            <typeparam name="TQuery">The query type.</typeparam>
+            <typeparam name="TResult">The result type.</typeparam>
+        </member>
+        <member name="M:Functional.CQS.IAsyncQueryHandler`2.HandleAsync(`0,System.Threading.CancellationToken)">
+            <summary>
+            Execute the query.
+            </summary>
+            <param name="parameters">The query parameters.</param>
+            <param name="cancellationToken">The cancellation token.</param>
+            <returns></returns>
+        </member>
+        <member name="T:Functional.CQS.ICommandHandler`2">
+            <summary>
+            Interface for synchronous command handlers.
+            </summary>
+            <typeparam name="TCommand">The command type.</typeparam>
+            <typeparam name="TError">The error type.</typeparam>
+        </member>
+        <member name="M:Functional.CQS.ICommandHandler`2.Handle(`0)">
+            <summary>
+            Execute the command.
+            </summary>
+            <param name="parameters">The command parameters.</param>
+            <returns></returns>
+        </member>
+        <member name="T:Functional.CQS.ICommandParameters`1">
+            <summary>
+            Marker interface used for associating command parameters with their corresponding error type.
+            </summary>
+            <typeparam name="TError">The error type.</typeparam>
+        </member>
+        <member name="T:Functional.CQS.IQueryHandler`2">
+            <summary>
+            Interface for synchronous query handlers.
+            </summary>
+            <typeparam name="TQuery">The query type.</typeparam>
+            <typeparam name="TResult">The result type.</typeparam>
+        </member>
+        <member name="M:Functional.CQS.IQueryHandler`2.Handle(`0)">
+            <summary>
+            Execute the query.
+            </summary>
+            <param name="parameters">The query parameters.</param>
+            <returns></returns>
+        </member>
+        <member name="T:Functional.CQS.IQueryParameters`1">
+            <summary>
+            Marker interface used for associating query parameters with their corresponding result type.
+            </summary>
+            <typeparam name="TResult">The result type.</typeparam>
+        </member>
+    </members>
+</doc>

--- a/src/Functional.CQS/IAsyncCommandHandler.cs
+++ b/src/Functional.CQS/IAsyncCommandHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Functional.CQS
+{
+	/// <summary>
+	/// Interface for asynchronous command handlers.
+	/// </summary>
+	/// <typeparam name="TCommand">The command type.</typeparam>
+	/// <typeparam name="TError">The error type.</typeparam>
+	public interface IAsyncCommandHandler<in TCommand, TError>
+		where TCommand : ICommandParameters<TError>
+	{
+		/// <summary>
+		/// Execute the command.
+		/// </summary>
+		/// <param name="parameters">The command parameters.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns></returns>
+		Task<Result<Unit, TError>> HandleAsync(TCommand parameters, CancellationToken cancellationToken);
+	}
+}

--- a/src/Functional.CQS/IAsyncCommandHandler.cs
+++ b/src/Functional.CQS/IAsyncCommandHandler.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace Functional.CQS
 {
 	/// <summary>
-	/// Interface for asynchronous command handlers.
+	/// Interface for asynchronous command handlers.  Intended to encapsulate application logic that changes the state of the system and can potentially fail.
 	/// </summary>
 	/// <typeparam name="TCommand">The command type.</typeparam>
 	/// <typeparam name="TError">The error type.</typeparam>

--- a/src/Functional.CQS/IAsyncCommandHandler.cs
+++ b/src/Functional.CQS/IAsyncCommandHandler.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace Functional.CQS
 {
 	/// <summary>
-	/// Interface for asynchronous command handlers.  Intended to encapsulate application logic that changes the state of the system and can potentially fail.
+	/// Interface for asynchronous command handlers.  Intended to encapsulate application logic that changes the state of the system and that can potentially fail.
 	/// </summary>
 	/// <typeparam name="TCommand">The command type.</typeparam>
 	/// <typeparam name="TError">The error type.</typeparam>

--- a/src/Functional.CQS/IAsyncQueryHandler.cs
+++ b/src/Functional.CQS/IAsyncQueryHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Functional.CQS
+{
+	/// <summary>
+	/// Interface for asynchronous query handlers.
+	/// </summary>
+	/// <typeparam name="TQuery">The query type.</typeparam>
+	/// <typeparam name="TResult">The result type.</typeparam>
+	public interface IAsyncQueryHandler<in TQuery, TResult>
+		where TQuery : IQueryParameters<TResult>
+	{
+		/// <summary>
+		/// Execute the query.
+		/// </summary>
+		/// <param name="parameters">The query parameters.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns></returns>
+		Task<TResult> HandleAsync(TQuery parameters, CancellationToken cancellationToken);
+	}
+}

--- a/src/Functional.CQS/IAsyncQueryHandler.cs
+++ b/src/Functional.CQS/IAsyncQueryHandler.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace Functional.CQS
 {
 	/// <summary>
-	/// Interface for asynchronous query handlers.
+	/// Interface for asynchronous query handlers.  Intended to encapsulate application logic that returns a result and is free of side effects (i.e. no observable changes made to system).
 	/// </summary>
 	/// <typeparam name="TQuery">The query type.</typeparam>
 	/// <typeparam name="TResult">The result type.</typeparam>

--- a/src/Functional.CQS/ICommandHandler.cs
+++ b/src/Functional.CQS/ICommandHandler.cs
@@ -1,7 +1,7 @@
 ﻿namespace Functional.CQS
 {
 	/// <summary>
-	/// Interface for synchronous command handlers.  Intended to encapsulate application logic that changes the state of the system and can potentially fail.
+	/// Interface for synchronous command handlers.  Intended to encapsulate application logic that changes the state of the system and that can potentially fail.
 	/// </summary>
 	/// <typeparam name="TCommand">The command type.</typeparam>
 	/// <typeparam name="TError">The error type.</typeparam>

--- a/src/Functional.CQS/ICommandHandler.cs
+++ b/src/Functional.CQS/ICommandHandler.cs
@@ -1,0 +1,18 @@
+﻿namespace Functional.CQS
+{
+	/// <summary>
+	/// Interface for synchronous command handlers.
+	/// </summary>
+	/// <typeparam name="TCommand">The command type.</typeparam>
+	/// <typeparam name="TError">The error type.</typeparam>
+	public interface ICommandHandler<in TCommand, TError>
+		where TCommand : ICommandParameters<TError>
+	{
+		/// <summary>
+		/// Execute the command.
+		/// </summary>
+		/// <param name="parameters">The command parameters.</param>
+		/// <returns></returns>
+		Result<Unit, TError> Handle(TCommand parameters);
+	}
+}

--- a/src/Functional.CQS/ICommandHandler.cs
+++ b/src/Functional.CQS/ICommandHandler.cs
@@ -1,7 +1,7 @@
 ﻿namespace Functional.CQS
 {
 	/// <summary>
-	/// Interface for synchronous command handlers.
+	/// Interface for synchronous command handlers.  Intended to encapsulate application logic that changes the state of the system and can potentially fail.
 	/// </summary>
 	/// <typeparam name="TCommand">The command type.</typeparam>
 	/// <typeparam name="TError">The error type.</typeparam>

--- a/src/Functional.CQS/ICommandParameters.cs
+++ b/src/Functional.CQS/ICommandParameters.cs
@@ -1,0 +1,11 @@
+﻿namespace Functional.CQS
+{
+	/// <summary>
+	/// Marker interface used for associating command parameters with their corresponding error type.
+	/// </summary>
+	/// <typeparam name="TError">The error type.</typeparam>
+	public interface ICommandParameters<TError>
+	{
+
+	}
+}

--- a/src/Functional.CQS/IQueryHandler.cs
+++ b/src/Functional.CQS/IQueryHandler.cs
@@ -3,7 +3,7 @@
 namespace Functional.CQS
 {
 	/// <summary>
-	/// Interface for synchronous query handlers.
+	/// Interface for synchronous query handlers.  Intended to encapsulate application logic that returns a result and is free of side effects (i.e. no observable changes made to system).
 	/// </summary>
 	/// <typeparam name="TQuery">The query type.</typeparam>
 	/// <typeparam name="TResult">The result type.</typeparam>

--- a/src/Functional.CQS/IQueryHandler.cs
+++ b/src/Functional.CQS/IQueryHandler.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Functional.CQS
+{
+	/// <summary>
+	/// Interface for synchronous query handlers.
+	/// </summary>
+	/// <typeparam name="TQuery">The query type.</typeparam>
+	/// <typeparam name="TResult">The result type.</typeparam>
+	public interface IQueryHandler<in TQuery, out TResult>
+		where TQuery : IQueryParameters<TResult>
+	{
+		/// <summary>
+		/// Execute the query.
+		/// </summary>
+		/// <param name="parameters">The query parameters.</param>
+		/// <returns></returns>
+		TResult Handle(TQuery parameters);
+	}
+}

--- a/src/Functional.CQS/IQueryParameters.cs
+++ b/src/Functional.CQS/IQueryParameters.cs
@@ -1,0 +1,11 @@
+﻿namespace Functional.CQS
+{
+	/// <summary>
+	/// Marker interface used for associating query parameters with their corresponding result type.
+	/// </summary>
+	/// <typeparam name="TResult">The result type.</typeparam>
+	public interface IQueryParameters<TResult>
+	{
+
+	}
+}


### PR DESCRIPTION
Defines the following generic contracts:
- `IQueryHandler<TQuery, TResult>`
- `IAsyncQueryHandler<TQuery, TResult>`
- `ICommandHandler<TCommand, TError>`
- `IAsyncCommandHandler<TCommand, TError>`