### PR TITLE
use StackExchange.Redis instead of ServiceStack.Redis package

### DIFF
--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/FunctionalRedisCacheTests.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/FunctionalRedisCacheTests.cs
@@ -93,14 +93,14 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		[DistributedCacheArrangement]
 		public async Task ShouldOnlyCallDataRetrievalMethodOnceWhenMultipleThreadsAccessCacheAtTheSameTime_NonGenericOverload(FunctionalRedisCache sut)
 		{
-			int numberOfCalls = 0;
-			await Parallel.ForEach(Enumerable.Range(0, 25), n => sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(int), () =>
+			int numberOfCallsMade = 0;
+			await Parallel.ForEach(Enumerable.Range(0, CONCURRENT_REQUEST_COUNT), n => sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(int), () =>
 			{
-				Interlocked.Increment(ref numberOfCalls);
+				Interlocked.Increment(ref numberOfCallsMade);
 				return n;
 			}, _ => true, TimeSpan.FromMinutes(5))).AsTask();
 
-			numberOfCalls.Should().Be(1);
+			numberOfCallsMade.Should().Be(1);
 		}
 
 		[Theory]
@@ -214,14 +214,14 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		[DistributedCacheArrangement]
 		public async Task ShouldOnlyCallDataRetrievalMethodOnceWhenMultipleThreadsAccessCacheAtTheSameTime_GenericOverload(FunctionalRedisCache sut)
 		{
-			int numberOfCalls = 0;
-			await Parallel.ForEach(Enumerable.Range(0, 25), n => sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), () =>
+			int numberOfCallsMade = 0;
+			await Parallel.ForEach(Enumerable.Range(0, CONCURRENT_REQUEST_COUNT), n => sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), () =>
 			{
-				Interlocked.Increment(ref numberOfCalls);
+				Interlocked.Increment(ref numberOfCallsMade);
 				return n.ToString();
 			}, _ => true, TimeSpan.FromMinutes(5))).AsTask();
 
-			numberOfCalls.Should().Be(1);
+			numberOfCallsMade.Should().Be(1);
 		}
 
 		[Theory]
@@ -255,15 +255,15 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		[DistributedCacheArrangement]
 		public async Task ShouldOnlyCallAsyncDataRetrievalMethodOnceWhenMultipleThreadsAccessCacheAtTheSameTime_NonGenericOverload(FunctionalRedisCache sut)
 		{
-			int numberOfCalls = 0;
-			var tasks = Enumerable.Range(0, 25).Select(x => Task.Run(() => sut.GetAsync(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(int), async () =>
+			int numberOfCallsMade = 0;
+			var tasks = Enumerable.Range(0, CONCURRENT_REQUEST_COUNT).Select(x => Task.Run(() => sut.GetAsync(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(int), async () =>
 			{
-				Interlocked.Increment(ref numberOfCalls);
+				Interlocked.Increment(ref numberOfCallsMade);
 				return await Task.FromResult(x);
 			}, _ => true, TimeSpan.FromMinutes(5)))).Cast<Task>().ToArray();
 
 			await Task.WhenAll(tasks);
-			numberOfCalls.Should().Be(1);
+			numberOfCallsMade.Should().Be(1);
 		}
 
 		[Theory]
@@ -327,15 +327,15 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		[DistributedCacheArrangement]
 		public async Task ShouldOnlyCallAsyncDataRetrievalMethodOnceWhenMultipleThreadsAccessCacheAtTheSameTime_GenericOverload(FunctionalRedisCache sut)
 		{
-			int numberOfCalls = 0;
-			var tasks = Enumerable.Range(0, 25).Select(x => Task.Run(() => sut.GetAsync(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), async () =>
+			int numberOfCallsMade = 0;
+			var tasks = Enumerable.Range(0, CONCURRENT_REQUEST_COUNT).Select(x => Task.Run(() => sut.GetAsync(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), async () =>
 			{
-				Interlocked.Increment(ref numberOfCalls);
+				Interlocked.Increment(ref numberOfCallsMade);
 				return await Task.FromResult(new object());
 			}, _ => true, TimeSpan.FromMinutes(5)))).Cast<Task>().ToArray();
 
 			await Task.WhenAll(tasks);
-			numberOfCalls.Should().Be(1);
+			numberOfCallsMade.Should().Be(1);
 		}
 
 		[Theory]
@@ -484,6 +484,8 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		#endregion
 
 		#region Data
+
+		private const int CONCURRENT_REQUEST_COUNT = 5;
 
 		private const string KEY1 = "1";
 		private const string KEY2A = "2a";

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/FunctionalRedisCacheTests.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/FunctionalRedisCacheTests.cs
@@ -401,8 +401,8 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		{
 			public void Customize(IFixture fixture)
 			{
-				// localhost = 127.0.0.1:6379 (per Redis convention at https://github.com/ServiceStack/ServiceStack.Redis#redis-connection-strings)
-				var cache = new FunctionalRedisCache(new FunctionalRedisCacheOptions("localhost"));
+				// localhost = 127.0.0.1:6379 (per Redis convention at https://stackexchange.github.io/StackExchange.Redis/Basics)
+				var cache = new FunctionalRedisCache(FunctionalRedisCacheConfiguration.ForLocalHostPort6379());
 				cache.Clear();
 				foreach (var item in _cacheItems)
 					cache.Add(item.Key, item.GroupKey, _cacheItemLookup[item.Key], TimeSpan.FromMinutes(5));

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/ConnectionMultiplexerExtensions.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/ConnectionMultiplexerExtensions.cs
@@ -1,0 +1,10 @@
+﻿using StackExchange.Redis;
+
+namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
+{
+	internal static class ConnectionMultiplexerExtensions
+	{
+		public static RedisClient GetRedisClient(this ConnectionMultiplexer source, FunctionalRedisCacheConfiguration configuration)
+			=> new RedisClient(source.GetServer(configuration.HostURL, configuration.PortNumber), source.GetDatabase());
+	}
+}

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/ConnectionMultiplexerExtensions.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/ConnectionMultiplexerExtensions.cs
@@ -4,7 +4,10 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 {
 	internal static class ConnectionMultiplexerExtensions
 	{
+		public static IServer GetServer(this ConnectionMultiplexer source, FunctionalRedisCacheConfiguration configuration)
+			=> source.GetServer(configuration.HostURL, configuration.PortNumber);
+
 		public static RedisClient GetRedisClient(this ConnectionMultiplexer source, FunctionalRedisCacheConfiguration configuration)
-			=> new RedisClient(source.GetServer(configuration.HostURL, configuration.PortNumber), source.GetDatabase());
+			=> new RedisClient(source.GetServer(configuration), source.GetDatabase());
 	}
 }

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.csproj
@@ -9,8 +9,8 @@
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching redis</PackageTags>
-    <Version>1.1.0</Version>
-    <PackageReleaseNotes>Added ability to inject custom JSON serializers into Redis cache implementation</PackageReleaseNotes>
+    <Version>2.0.0</Version>
+    <PackageReleaseNotes>Migrated from ServiceStack.Redis to StackExchange.Redis, as the former is a commercial product with free use limitations and the latter is a free use library under MIT license</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -52,7 +52,7 @@
     <PackageReference Include="Functional.Primitives" Version="1.9.0" />
     <PackageReference Include="Functional.Primitives.Extensions" Version="1.9.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="ServiceStack.Redis" Version="5.4.0" />
+    <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/FunctionalRedisCache.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/FunctionalRedisCache.cs
@@ -166,7 +166,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 		/// </summary>
 		public Result<Unit, Exception> Clear()
 		{
-			return Result.Try(() => _managerPool.GetServer(_configuration.HostURL, _configuration.PortNumber).FlushDatabase());
+			return Result.Try(() => _managerPool.GetServer(_configuration).FlushDatabase());
 		}
 
 		/// <summary>
@@ -179,8 +179,12 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 				var client = _managerPool.GetRedisClient(_configuration);
 
 				int itemCount = client.Server.Keys().Count();
-				int keyToGroupKeyItemCount = client.CountKeyToGroupKeyAssociationItems().Match(value => value, ex => throw new Exception($"An error occurred while attempting to compute '{nameof(KeyToGroupKeyItemCount)}'!", ex));
-				int groupKeySetItemCount = client.CountGroupKeySetItems().Match(value => value, ex => throw new Exception($"An error occurred while attempting to compute '{nameof(GroupKeySetItemCount)}'!", ex));
+				int keyToGroupKeyItemCount = client.CountKeyToGroupKeyAssociationItems().Match(
+					value => value,
+					ex => throw new Exception($"An error occurred while attempting to compute '{nameof(KeyToGroupKeyItemCount)}'!", ex));
+				int groupKeySetItemCount = client.CountGroupKeySetItems().Match(
+					value => value,
+					ex => throw new Exception($"An error occurred while attempting to compute '{nameof(GroupKeySetItemCount)}'!", ex));
 
 				return itemCount - keyToGroupKeyItemCount - groupKeySetItemCount;
 			}
@@ -194,7 +198,9 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 			get
 			{
 				var client = _managerPool.GetRedisClient(_configuration);
-				return client.CountKeyToGroupKeyAssociationItems().Match(value => value, ex => throw new Exception($"An error occurred while attempting to compute '{nameof(KeyToGroupKeyItemCount)}'!", ex));
+				return client.CountKeyToGroupKeyAssociationItems().Match(
+					value => value,
+					ex => throw new Exception($"An error occurred while attempting to compute '{nameof(KeyToGroupKeyItemCount)}'!", ex));
 			}
 		}
 
@@ -206,7 +212,9 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 			get
 			{
 				var client = _managerPool.GetRedisClient(_configuration);
-				return client.CountGroupKeySetItems().Match(value => value, ex => throw new Exception($"An error occurred while attempting to compute '{nameof(GroupKeySetItemCount)}'!", ex));
+				return client.CountGroupKeySetItems().Match(
+					value => value,
+					ex => throw new Exception($"An error occurred while attempting to compute '{nameof(GroupKeySetItemCount)}'!", ex));
 			}
 		}
 

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/FunctionalRedisCacheConfiguration.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/FunctionalRedisCacheConfiguration.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
+{
+	/// <summary>
+	/// Encapsulates Redis cache configuration.
+	/// </summary>
+	public class FunctionalRedisCacheConfiguration
+	{
+		private const string LOCALHOST = "localhost";
+
+		private FunctionalRedisCacheConfiguration(string hostURL, int portNumber, params JsonConverter[] jsonConverterCollection)
+		{
+			HostURL = hostURL ?? throw new ArgumentNullException(nameof(hostURL));
+			PortNumber = portNumber;
+			JsonConverterCollection = jsonConverterCollection ?? throw new ArgumentNullException(nameof(jsonConverterCollection));
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FunctionalRedisCacheConfiguration"/> class.
+		/// </summary>
+		/// <param name="jsonConverterCollection">The collection of custom JSON converters.</param>
+		public static FunctionalRedisCacheConfiguration ForLocalHostPort6379(params JsonConverter[] jsonConverterCollection)
+			=> new FunctionalRedisCacheConfiguration(LOCALHOST, 6379, jsonConverterCollection);
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FunctionalRedisCacheConfiguration"/> class.
+		/// </summary>
+		/// <param name="portNumber">The port number.</param>
+		/// <param name="jsonConverterCollection">The collection of custom JSON converters.</param>
+		public static FunctionalRedisCacheConfiguration ForLocalHost(int portNumber, params JsonConverter[] jsonConverterCollection)
+			=> new FunctionalRedisCacheConfiguration(LOCALHOST, portNumber, jsonConverterCollection);
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="FunctionalRedisCacheConfiguration"/> class.
+		/// </summary>
+		/// <param name="hostURL">The host URL.</param>
+		/// <param name="portNumber">The port number.</param>
+		/// <param name="jsonConverterCollection">The collection of custom JSON converters.</param>
+		public static FunctionalRedisCacheConfiguration ForRemoteHost(string hostURL, int portNumber, params JsonConverter[] jsonConverterCollection)
+			=> new FunctionalRedisCacheConfiguration(hostURL, portNumber, jsonConverterCollection);
+
+		/// <summary>
+		/// The host URL for the Redis cache.
+		/// </summary>
+		public string HostURL { get; }
+
+		/// <summary>
+		/// The port number.
+		/// </summary>
+		public int PortNumber { get; }
+
+		/// <summary>
+		/// The collection of custom JSON converters.
+		/// </summary>
+		public JsonConverter[] JsonConverterCollection { get; }
+	}
+}

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/FunctionalRedisCacheOptions.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/FunctionalRedisCacheOptions.cs
@@ -6,6 +6,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 	/// <summary>
 	/// Encapsulates Redis cache configuration options.
 	/// </summary>
+	[Obsolete("Use FunctionalRedisCacheConfiguration instead.")]
 	public class FunctionalRedisCacheOptions
 	{
 		/// <summary>

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/RedisClient.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/RedisClient.cs
@@ -1,0 +1,16 @@
+﻿using StackExchange.Redis;
+
+namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
+{
+	internal class RedisClient
+	{
+		public RedisClient(IServer server, IDatabase database)
+		{
+			Server = server;
+			Database = database;
+		}
+
+		public IServer Server { get; }
+		public IDatabase Database { get; }
+	}
+}

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/RedisClientExtensions.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/RedisClientExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -6,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using Newtonsoft.Json;
-using ServiceStack.Redis;
+using StackExchange.Redis;
 
 namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 {
@@ -32,35 +33,40 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 			{ _countGroupKeyItems, _assembly.LoadScript("countGroupKeyItems.lua").Match(value => value, ex => throw ex) }
 		};
 
-		public static Result<bool, Exception> SetSafely<T>(this IRedisClient client, string key, T item, TimeSpan timeToLive, JsonSerializerSettings serializerSettings) => Result.Try(() => client.Set(key, item.ToJsonString(serializerSettings), timeToLive));
+		private static readonly ConcurrentDictionary<string, LoadedLuaScript> _loadedLuaScripts = new ConcurrentDictionary<string, LoadedLuaScript>();
 
-		public static Result<RedisText, Exception> SetWithGroupKeySafely<T>(this IRedisClient client, string key, string groupKey, T item, TimeSpan timeToLive, JsonSerializerSettings serializerSettings)
+		public static bool ContainsKey(this RedisClient client, string key) => client.Database.StringGet(key).HasValue;
+		public static string GetValue(this RedisClient client, string key) => client.Database.StringGet(key).ToString();
+
+		public static Result<bool, Exception> SetSafely<T>(this RedisClient client, string key, T item, TimeSpan timeToLive, JsonSerializerSettings serializerSettings) => Result.Try(() => client.Database.StringSet(key, item.ToJsonString(serializerSettings), timeToLive));
+
+		public static Result<RedisValue, Exception> SetWithGroupKeySafely<T>(this RedisClient client, string key, string groupKey, T item, TimeSpan timeToLive, JsonSerializerSettings serializerSettings)
 		{
 			var keys = new[] { key, groupKey };
 			var args = new[] { item.ToJsonString(serializerSettings), ((int) timeToLive.TotalSeconds).ToString(CultureInfo.InvariantCulture), KEY_TO_GROUP_KEY_PREFIX, GROUP_KEY_PREFIX };
 			return client.ExecCachedLua(_scriptLookup[_addItemWithGroupKeyScriptID], sha1 => client.ExecuteLuaShaSafely(sha1, keys, args));
 		}
 
-		public static Result<RedisText, Exception> RemoveSafely(this IRedisClient client, string key)
+		public static Result<RedisValue, Exception> RemoveSafely(this RedisClient client, string key)
 		{
 			var keys = new[] { key, };
 			var args = new[] { KEY_TO_GROUP_KEY_PREFIX };
 			return client.ExecCachedLua(_scriptLookup[_removeItemScriptID], sha1 => client.ExecuteLuaShaSafely(sha1, keys, args));
 		}
 
-		public static Result<RedisText, Exception> RemoveGroupSafely(this IRedisClient client, string groupKey)
+		public static Result<RedisValue, Exception> RemoveGroupSafely(this RedisClient client, string groupKey)
 		{
 			var keys = new[] { groupKey };
 			var args = new[] { KEY_TO_GROUP_KEY_PREFIX, GROUP_KEY_PREFIX };
 			return client.ExecCachedLua(_scriptLookup[_removeItemGroupScriptID], sha1 => client.ExecuteLuaShaSafely(sha1, keys, args));
 		}
 
-		public static Result<int, Exception> CountKeyToGroupKeyAssociationItems(this IRedisClient client)
+		public static Result<int, Exception> CountKeyToGroupKeyAssociationItems(this RedisClient client)
 		{
 			return client.ExecCachedLua(_scriptLookup[_countKeyToGroupKeyAssociationItems], sha1 => client.ExecuteLuaShaAsListSafely(sha1, new string[] { }, new[] { KEY_TO_GROUP_KEY_PREFIX }).Select(results => results.Count()));
 		}
 
-		public static Result<int, Exception> CountGroupKeySetItems(this IRedisClient client)
+		public static Result<int, Exception> CountGroupKeySetItems(this RedisClient client)
 		{
 			return client.ExecCachedLua(_scriptLookup[_countGroupKeyItems], sha1 => client.ExecuteLuaShaAsListSafely(sha1, new string[] { }, new[] { GROUP_KEY_PREFIX })).Select(results => results.Count());
 		}
@@ -78,7 +84,21 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 			});
 		}
 
-		private static Result<RedisText, Exception> ExecuteLuaShaSafely(this IRedisClient client, string sha1, string[] keys, string[] args) => Result.Try(() => client.ExecLuaSha(sha1, keys, args));
-		private static Result<IEnumerable<string>, Exception> ExecuteLuaShaAsListSafely(this IRedisClient client, string sha1, string[] keys, string[] args) => Result.Try(() => client.ExecLuaShaAsList(sha1, keys, args).AsEnumerable());
+		private static Result<RedisValue, Exception> ExecuteLuaShaSafely(this RedisClient client, LoadedLuaScript script, string[] keys, string[] args) => Result.Try(() => (RedisValue)client.ExecuteScript(script, keys, args));
+		private static Result<string[], Exception> ExecuteLuaShaAsListSafely(this RedisClient client, LoadedLuaScript script, string[] keys, string[] args) => Result.Try(() => (string[])client.ExecuteScript(script, keys, args));
+
+		private static T ExecCachedLua<T>(this RedisClient client, string script, Func<LoadedLuaScript, T> factory)
+		{
+			var luaScript = _loadedLuaScripts.GetOrAdd(script, s =>
+			{
+				var preparedScript = LuaScript.Prepare(s);
+				return preparedScript.Load(client.Server);
+			});
+
+			return factory.Invoke(luaScript);
+		}
+
+		private static RedisResult ExecuteScript(this RedisClient client, LoadedLuaScript script, string[] keys, string[] args)
+			=> client.Database.ScriptEvaluate(script.Hash, keys.Select(x => (RedisKey)x).ToArray(), args.Select(x => (RedisValue)x).ToArray());
 	}
 }

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/RedisClientExtensions.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/RedisClientExtensions.cs
@@ -84,8 +84,11 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis
 			});
 		}
 
-		private static Result<RedisValue, Exception> ExecuteLuaShaSafely(this RedisClient client, LoadedLuaScript script, string[] keys, string[] args) => Result.Try(() => (RedisValue)client.ExecuteScript(script, keys, args));
-		private static Result<string[], Exception> ExecuteLuaShaAsListSafely(this RedisClient client, LoadedLuaScript script, string[] keys, string[] args) => Result.Try(() => (string[])client.ExecuteScript(script, keys, args));
+		private static Result<RedisValue, Exception> ExecuteLuaShaSafely(this RedisClient client, LoadedLuaScript script, string[] keys, string[] args)
+			=> Result.Try(() => (RedisValue)client.ExecuteScript(script, keys, args));
+
+		private static Result<string[], Exception> ExecuteLuaShaAsListSafely(this RedisClient client, LoadedLuaScript script, string[] keys, string[] args)
+			=> Result.Try(() => (string[])client.ExecuteScript(script, keys, args));
 
 		private static T ExecCachedLua<T>(this RedisClient client, string script, Func<LoadedLuaScript, T> factory)
 		{


### PR DESCRIPTION
As pointed out in #19 , the `ServiceStack.Redis` is a commercial product with free use caps and `StackExchange.Redis` is a free use library under MIT license.  I have made the library replacement.