### PR TITLE
Use `Functional 2.0.0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: csharp
 mono: none
 sudo: required
 dist: xenial
-dotnet: 2.2
+dotnet: 3.1
 
 services:
  - redis-server

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests.csproj
@@ -1,20 +1,20 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
-    <PackageReference Include="FakeItEasy" Version="5.0.1" />
-    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="1.0.0" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="FakeItEasy" Version="5.5.0" />
+    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="2.0.0" />
     <PackageReference Include="Jmansar.SemanticComparisonExtensions.NetStandard" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="SemanticComparison" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="SemanticComparison" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/FunctionalRedisCacheTests.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/FunctionalRedisCacheTests.cs
@@ -73,7 +73,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, groupKey, typeof(int), () => KEY_TO_STORE, _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(KEY_TO_STORE));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(KEY_TO_STORE);
 			sut.VerifyOneNewItemHasBeenAdded(_cacheItems, groupKey);
 		}
 
@@ -85,7 +85,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = sut.Get(KEY3, Option.None<string>(), _cacheItemLookup[KEY3].GetType(), () => (SampleStructData)_cacheItemLookup[KEY3], _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY3).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be((SampleStructData)_cacheItemLookup[KEY3]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be((SampleStructData)_cacheItemLookup[KEY3]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -114,7 +114,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, groupKey, () => itemToStore, _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(itemToStore));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(itemToStore);
 			sut.VerifyOneNewItemHasBeenAdded(_cacheItems, groupKey);
 		}
 
@@ -126,7 +126,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = sut.Get(KEY1, Option.None<string>(), () => (string)_cacheItemLookup[KEY1], _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY1).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be((string)_cacheItemLookup[KEY1]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be((string)_cacheItemLookup[KEY1]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -138,7 +138,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = sut.Get(KEY2A, Option.None<string>(), () => (IEnumerable<int>)_cacheItemLookup[KEY2A], _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY2A).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().BeEquivalentTo((IEnumerable<int>)_cacheItemLookup[KEY2A]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().BeEquivalentTo((IEnumerable<int>)_cacheItemLookup[KEY2A]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -150,7 +150,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = sut.Get(KEY2B, Option.None<string>(), () => (SampleReferenceData)_cacheItemLookup[KEY2B], _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY2B).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be((SampleReferenceData)_cacheItemLookup[KEY2B]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be((SampleReferenceData)_cacheItemLookup[KEY2B]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -158,7 +158,13 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		[DistributedCacheArrangement]
 		public void ShouldNotStoreOptionInCacheIfConfiguredToNotStoreNone(FunctionalRedisCache sut)
 		{
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => Option.None<int>(), option => ((Option<int>)option).HasValue(), TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Option<int>)value).Should().NotHaveValue());
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => Option.None<int>(), option => ((Option<int>)option).HasValue(), TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Option<int>>()
+				.Should()
+				.NotHaveValue();
+
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeFalse("configured to not store Option.None in the cache");
 		}
 
@@ -167,8 +173,26 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		public void ShouldReturnOptionSomeItemFromCache(FunctionalRedisCache sut)
 		{
 			const int VALUE = 1337;
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => Option.Some(VALUE), option => ((Option<int>)option).HasValue(), TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Option<int>)value).Should().HaveExpectedValue(VALUE));
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => throw new NotImplementedException(), option => ((Option<int>)option).HasValue(), TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Option<int>)value).Should().HaveExpectedValue(VALUE));
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => Option.Some(VALUE), option => ((Option<int>)option).HasValue(), TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Option<int>>()
+				.Should()
+				.HaveValue()
+				.AndValue
+				.Should()
+				.Be(VALUE);
+
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => throw new NotImplementedException(), option => ((Option<int>)option).HasValue(), TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Option<int>>()
+				.Should()
+				.HaveValue()
+				.AndValue
+				.Should()
+				.Be(VALUE);
+
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue("configured to store Option.Some in the cache");
 		}
 
@@ -176,8 +200,20 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		[DistributedCacheArrangement]
 		public void ShouldReturnOptionNoneItemFromCache(FunctionalRedisCache sut)
 		{
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => Option.None<int>(), option => true, TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Option<int>)value).Should().NotHaveValue());
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => throw new NotImplementedException(), option => true, TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Option<int>)value).Should().NotHaveValue());
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => Option.None<int>(), option => true, TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Option<int>>()
+				.Should()
+				.NotHaveValue();
+
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Option<int>), () => throw new NotImplementedException(), option => true, TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Option<int>>()
+				.Should()
+				.NotHaveValue();
+
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue("configured to store Option.None in the cache");
 		}
 
@@ -186,7 +222,16 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		public void ShouldNotStoreResultInCacheIfConfiguredToNotStoreFaultedResult(FunctionalRedisCache sut)
 		{
 			const string FAIL_VALUE = "all your base are belong to us";
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => Result.Failure<int, string>(FAIL_VALUE), result => ((Result<int, string>)result).IsSuccess(), TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Result<int, string>)value).Should().BeFaultedWithExpectedValue(FAIL_VALUE));
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => Result.Failure<int, string>(FAIL_VALUE), result => ((Result<int, string>)result).IsSuccess(), TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Result<int, string>>()
+				.Should()
+				.BeFaulted()
+				.AndFailureValue
+				.Should()
+				.Be(FAIL_VALUE);
+
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeFalse("configured to not store Result.Fail in the cache");
 		}
 
@@ -195,8 +240,26 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		public void ShouldReturnSuccessfulResultItemFromCache(FunctionalRedisCache sut)
 		{
 			const int SUCCESS_VALUE = 1337;
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => Result.Success<int, string>(SUCCESS_VALUE), result => ((Result<int, string>)result).IsSuccess(), TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Result<int, string>)value).Should().BeSuccessfulWithExpectedValue(SUCCESS_VALUE));
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => throw new NotImplementedException(), result => ((Result<int, string>)result).IsSuccess(), TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Result<int, string>)value).Should().BeSuccessfulWithExpectedValue(SUCCESS_VALUE));
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => Result.Success<int, string>(SUCCESS_VALUE), result => ((Result<int, string>)result).IsSuccess(), TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Result<int, string>>()
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue
+				.Should()
+				.Be(SUCCESS_VALUE);
+
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => throw new NotImplementedException(), result => ((Result<int, string>)result).IsSuccess(), TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Result<int, string>>()
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue
+				.Should()
+				.Be(SUCCESS_VALUE);
+
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue("configured to store Result.Success in the cache");
 		}
 
@@ -205,8 +268,26 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 		public void ShouldReturnFaultedResultItemFromCache(FunctionalRedisCache sut)
 		{
 			const string FAIL_VALUE = "all your base are belong to us";
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => Result.Failure<int, string>(FAIL_VALUE), result => true, TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Result<int, string>)value).Should().BeFaultedWithExpectedValue(FAIL_VALUE));
-			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => throw new NotImplementedException(), result => true, TimeSpan.FromMinutes(5)).Should().BeSuccessful(value => ((Result<int, string>)value).Should().BeFaultedWithExpectedValue(FAIL_VALUE));
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => Result.Failure<int, string>(FAIL_VALUE), result => true, TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Result<int, string>>()
+				.Should()
+				.BeFaulted()
+				.AndFailureValue
+				.Should()
+				.Be(FAIL_VALUE);
+
+			sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, Option.None<string>(), typeof(Result<int, string>), () => throw new NotImplementedException(), result => true, TimeSpan.FromMinutes(5))
+				.Should()
+				.BeSuccessful()
+				.AndSuccessValue.As<Result<int, string>>()
+				.Should()
+				.BeFaulted()
+				.AndFailureValue
+				.Should()
+				.Be(FAIL_VALUE);
+
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue("configured to store Result.Fail in the cache");
 		}
 
@@ -235,7 +316,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = await sut.GetAsync(KEY_NOT_IN_ORIGINAL_CACHE, groupKey, typeof(int), () => Task.FromResult((object)KEY_TO_STORE), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(KEY_TO_STORE));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(KEY_TO_STORE);
 			sut.VerifyOneNewItemHasBeenAdded(_cacheItems, groupKey);
 		}
 
@@ -247,7 +328,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = await sut.GetAsync(KEY3, Option.None<string>(), _cacheItemLookup[KEY3].GetType(), () => Task.FromResult<object>((SampleStructData)_cacheItemLookup[KEY3]), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY3).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be((SampleStructData)_cacheItemLookup[KEY3]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be((SampleStructData)_cacheItemLookup[KEY3]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -277,7 +358,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = await sut.GetAsync(KEY_NOT_IN_ORIGINAL_CACHE, groupKey, () => Task.FromResult(itemToStore), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(itemToStore));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(itemToStore);
 			sut.VerifyOneNewItemHasBeenAdded(_cacheItems, groupKey);
 		}
 
@@ -291,7 +372,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = await sut.GetAsync(KEY1, groupKey, () => Task.FromResult((string)_cacheItemLookup[KEY1]), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY1).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be((string)_cacheItemLookup[KEY1]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be((string)_cacheItemLookup[KEY1]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -305,7 +386,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = await sut.GetAsync(KEY2A, groupKey, () => Task.FromResult((IEnumerable<int>)_cacheItemLookup[KEY2A]), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY2A).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().BeEquivalentTo((IEnumerable<int>)_cacheItemLookup[KEY2A]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().BeEquivalentTo((IEnumerable<int>)_cacheItemLookup[KEY2A]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -319,7 +400,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var result = await sut.GetAsync(KEY2B, groupKey, () => Task.FromResult((SampleReferenceData)_cacheItemLookup[KEY2B]), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY2B).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be((SampleReferenceData)_cacheItemLookup[KEY2B]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be((SampleReferenceData)_cacheItemLookup[KEY2B]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/JsonConverters/OptionJsonConverterTests.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/JsonConverters/OptionJsonConverterTests.cs
@@ -32,7 +32,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Option.Some(SUCCESS_VALUE), _jsonSerializerSettings);
 			var fromJson = JsonConvert.DeserializeObject<Option<int>>(json, _jsonSerializerSettings);
 
-			fromJson.Should().HaveExpectedValue(SUCCESS_VALUE);
+			fromJson.Should().HaveValue().AndValue.Should().Be(SUCCESS_VALUE);
 		}
 
 		[Fact]
@@ -42,7 +42,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Option.Some(SUCCESS_VALUE), _jsonSerializerSettings);
 			var fromJson = JsonConvert.DeserializeObject<Option<string>>(json, _jsonSerializerSettings);
 
-			fromJson.Should().HaveExpectedValue(SUCCESS_VALUE);
+			fromJson.Should().HaveValue().AndValue.Should().Be(SUCCESS_VALUE);
 		}
 
 		[Fact]
@@ -52,7 +52,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Option.Some(collection), _jsonSerializerSettings);
 			var fromJson = JsonConvert.DeserializeObject<Option<IEnumerable<int>>>(json, _jsonSerializerSettings);
 
-			fromJson.Should().HaveValue(x => x.SequenceEqual(collection).Should().BeTrue());
+			fromJson.Should().HaveValue().AndValue.SequenceEqual(collection).Should().BeTrue();
 		}
 
 		[Fact]
@@ -62,7 +62,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Option.Some(array), _jsonSerializerSettings);
 			var fromJson = JsonConvert.DeserializeObject<Option<int[]>>(json, _jsonSerializerSettings);
 
-			fromJson.Should().HaveValue(x => x.SequenceEqual(array).Should().BeTrue());
+			fromJson.Should().HaveValue().AndValue.SequenceEqual(array).Should().BeTrue();
 		}
 
 		[Fact]
@@ -72,7 +72,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Option.Some(obj), _jsonSerializerSettings);
 			var fromJson = JsonConvert.DeserializeObject<Option<AppModel>>(json, _jsonSerializerSettings);
 
-			fromJson.Should().HaveValue(x => x.IsLike(obj));
+			fromJson.Should().HaveValue().AndValue.IsLike(obj);
 		}
 
 		[Fact]
@@ -82,7 +82,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Option.Some(obj), _jsonSerializerSettings);
 			var fromJson = JsonConvert.DeserializeObject<Option<AppModelWithVersion>>(json, _jsonSerializerSettings);
 
-			fromJson.Should().HaveValue(x => x.IsLike(obj));
+			fromJson.Should().HaveValue().AndValue.IsLike(obj);
 		}
 
 		[Fact]

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/JsonConverters/ResultJsonConverterTests.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests/JsonConverters/ResultJsonConverterTests.cs
@@ -40,7 +40,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<int, string>(SUCCESS_VALUE));
 			var fromJson = (Result<int, string>)JsonConvert.DeserializeObject(json, typeof(Result<int, string>));
 
-			fromJson.Should().BeSuccessfulWithExpectedValue(SUCCESS_VALUE);
+			fromJson.Should().BeSuccessful().AndSuccessValue.Should().Be(SUCCESS_VALUE);
 		}
 
 		[Fact]
@@ -50,7 +50,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<IEnumerable<int>, Exception>(collection));
 			var fromJson = (Result<IEnumerable<int>, Exception>)JsonConvert.DeserializeObject(json, typeof(Result<IEnumerable<int>, Exception>));
 
-			fromJson.Should().BeSuccessful(x => x.SequenceEqual(collection).Should().BeTrue());
+			fromJson.Should().BeSuccessful().AndSuccessValue.SequenceEqual(collection).Should().BeTrue();
 		}
 
 		[Fact]
@@ -60,7 +60,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<int[], Exception>(array));
 			var fromJson = (Result<int[], Exception>)JsonConvert.DeserializeObject(json, typeof(Result<int[], Exception>));
 
-			fromJson.Should().BeSuccessful(x => x.SequenceEqual(array).Should().BeTrue());
+			fromJson.Should().BeSuccessful().AndSuccessValue.SequenceEqual(array).Should().BeTrue();
 		}
 
 		[Fact]
@@ -70,7 +70,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<AppModel, Exception>(obj));
 			var fromJson = (Result<AppModel, Exception>)JsonConvert.DeserializeObject(json, typeof(Result<AppModel, Exception>));
 
-			fromJson.Should().BeSuccessful(x => x.IsLike(obj));
+			fromJson.Should().BeSuccessful().AndSuccessValue.IsLike(obj);
 		}
 
 		[Fact]
@@ -80,7 +80,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<AppModelWithVersion, Exception>(obj));
 			var fromJson = (Result<AppModelWithVersion, Exception>)JsonConvert.DeserializeObject(json, typeof(Result<AppModelWithVersion, Exception>));
 
-			fromJson.Should().BeSuccessful(x => x.IsLike(obj));
+			fromJson.Should().BeSuccessful().AndSuccessValue.IsLike(obj);
 		}
 
 		[Fact]
@@ -90,7 +90,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<Option<AppModel>, Exception>(Option.Some(obj)));
 			var fromJson = (Result<Option<AppModel>, Exception>)JsonConvert.DeserializeObject(json, typeof(Result<Option<AppModel>, Exception>));
 
-			fromJson.Should().BeSuccessful(option => option.Should().HaveValue(x => x.IsLike(obj)));
+			fromJson.Should().BeSuccessful().AndSuccessValue.Should().HaveValue().AndValue.IsLike(obj);
 		}
 
 		[Fact]
@@ -99,7 +99,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<Option<AppModel>, Exception>(Option.None<AppModel>()));
 			var fromJson = (Result<Option<AppModel>, Exception>)JsonConvert.DeserializeObject(json, typeof(Result<Option<AppModel>, Exception>));
 
-			fromJson.Should().BeSuccessful(option => option.Should().NotHaveValue());
+			fromJson.Should().BeSuccessful().AndSuccessValue.Should().NotHaveValue();
 		}
 
 		[Fact]
@@ -109,7 +109,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<Option<AppModelWithVersion>, Exception>(Option.Some(obj)));
 			var fromJson = (Result<Option<AppModelWithVersion>, Exception>)JsonConvert.DeserializeObject(json, typeof(Result<Option<AppModelWithVersion>, Exception>));
 
-			fromJson.Should().BeSuccessful(option => option.Should().HaveValue(x => x.IsLike(obj)));
+			fromJson.Should().BeSuccessful().AndSuccessValue.Should().HaveValue().AndValue.IsLike(obj);
 		}
 
 		[Fact]
@@ -118,7 +118,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Success<Option<AppModelWithVersion>, Exception>(Option.None<AppModelWithVersion>()));
 			var fromJson = (Result<Option<AppModelWithVersion>, Exception>)JsonConvert.DeserializeObject(json, typeof(Result<Option<AppModelWithVersion>, Exception>));
 
-			fromJson.Should().BeSuccessful(option => option.Should().NotHaveValue());
+			fromJson.Should().BeSuccessful().AndSuccessValue.Should().NotHaveValue();
 		}
 
 		[Fact]
@@ -138,7 +138,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<int, string>(FAIL_VALUE));
 			var fromJson = JsonConvert.DeserializeObject<Result<int, string>>(json, new ResultJsonConverter());
 
-			fromJson.Should().BeFaultedWithExpectedValue(FAIL_VALUE);
+			fromJson.Should().BeFaulted().AndFailureValue.Should().Be(FAIL_VALUE);
 		}
 
 		[Fact]
@@ -148,7 +148,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<IEnumerable<int>, IEnumerable<string>>(collection));
 			var fromJson = (Result<IEnumerable<int>, IEnumerable<string>>)JsonConvert.DeserializeObject(json, typeof(Result<IEnumerable<int>, IEnumerable<string>>));
 
-			fromJson.Should().BeFaulted(x => x.SequenceEqual(collection).Should().BeTrue());
+			fromJson.Should().BeFaulted().AndFailureValue.SequenceEqual(collection).Should().BeTrue();
 		}
 
 		[Fact]
@@ -158,7 +158,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<int[], string[]>(array));
 			var fromJson = (Result<int[], string[]>)JsonConvert.DeserializeObject(json, typeof(Result<int[], string[]>));
 
-			fromJson.Should().BeFaulted(x => x.SequenceEqual(array).Should().BeTrue());
+			fromJson.Should().BeFaulted().AndFailureValue.SequenceEqual(array).Should().BeTrue();
 		}
 
 		[Fact]
@@ -168,7 +168,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<AppModel, AppError>(obj));
 			var fromJson = (Result<AppModel, AppError>)JsonConvert.DeserializeObject(json, typeof(Result<AppModel, AppError>));
 
-			fromJson.Should().BeFaulted(x => x.IsLike(obj));
+			fromJson.Should().BeFaulted().AndFailureValue.IsLike(obj);
 		}
 
 		[Fact]
@@ -178,13 +178,14 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<AppModelWithVersion, Exception>(exception));
 			var fromJson = (Result<AppModelWithVersion, Exception>)JsonConvert.DeserializeObject(json, typeof(Result<AppModelWithVersion, Exception>));
 
-			fromJson.Should().BeFaulted(x =>
-			{
-				x.AsSource().OfLikeness<Exception>()
-					.WithInnerLikeness(d => d.InnerException, s => s.InnerException, l => l.Without(ex => ex.Data))
-					.Without(ex => ex.Data)
-					.ShouldEqual(exception);
-			});
+			fromJson
+				.Should()
+				.BeFaulted()
+				.AndFailureValue
+				.AsSource().OfLikeness<Exception>()
+				.WithInnerLikeness(d => d.InnerException, s => s.InnerException, l => l.Without(ex => ex.Data))
+				.Without(ex => ex.Data)
+				.ShouldEqual(exception);
 		}
 
 		[Fact]
@@ -194,7 +195,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<AppModel, Option<AppError>>(Option.Some(obj)));
 			var fromJson = (Result<AppModel, Option<AppError>>)JsonConvert.DeserializeObject(json, typeof(Result<AppModel, Option<AppError>>));
 
-			fromJson.Should().BeFaulted(option => option.Should().HaveValue(x => x.IsLike(obj)));
+			fromJson.Should().BeFaulted().AndFailureValue.Should().HaveValue().AndValue.IsLike(obj);
 		}
 
 		[Fact]
@@ -203,7 +204,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<AppModel, Option<AppError>>(Option.None<AppError>()));
 			var fromJson = (Result<AppModel, Option<AppError>>)JsonConvert.DeserializeObject(json, typeof(Result<AppModel, Option<AppError>>));
 
-			fromJson.Should().BeFaulted(option => option.Should().NotHaveValue());
+			fromJson.Should().BeFaulted().AndFailureValue.Should().NotHaveValue();
 		}
 
 		[Fact]
@@ -213,13 +214,17 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<AppModelWithVersion, Option<Exception>>(Option.Some(exception)));
 			var fromJson = (Result<AppModelWithVersion, Option<Exception>>)JsonConvert.DeserializeObject(json, typeof(Result<AppModelWithVersion, Option<Exception>>));
 
-			fromJson.Should().BeFaulted(option => option.Should().HaveValue(x =>
-			{
-				x.AsSource().OfLikeness<Exception>()
-					.WithInnerLikeness(d => d.InnerException, s => s.InnerException, l => l.Without(ex => ex.Data))
-					.Without(ex => ex.Data)
-					.ShouldEqual(exception);
-			}));
+			fromJson
+				.Should()
+				.BeFaulted()
+				.AndFailureValue
+				.Should()
+				.HaveValue()
+				.AndValue
+				.AsSource().OfLikeness<Exception>()
+				.WithInnerLikeness(d => d.InnerException, s => s.InnerException, l => l.Without(ex => ex.Data))
+				.Without(ex => ex.Data)
+				.ShouldEqual(exception);
 		}
 
 		[Fact]
@@ -228,7 +233,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.Tests
 			var json = JsonConvert.SerializeObject(Result.Failure<AppModelWithVersion, Option<Exception>>(Option.None<Exception>()));
 			var fromJson = (Result<AppModelWithVersion, Option<Exception>>)JsonConvert.DeserializeObject(json, typeof(Result<AppModelWithVersion, Option<Exception>>));
 
-			fromJson.Should().BeFaulted(option => option.Should().NotHaveValue());
+			fromJson.Should().BeFaulted().AndFailureValue.Should().NotHaveValue();
 		}
 	}
 }

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.csproj
@@ -9,8 +9,8 @@
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching redis</PackageTags>
-    <Version>2.1.0</Version>
-    <PackageReleaseNotes>Added ability to specify password for remote Redis connection</PackageReleaseNotes>
+    <Version>3.0.0</Version>
+    <PackageReleaseNotes>Updated to Functional 2.0.0</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -48,10 +48,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Common.Extensions" Version="1.9.0" />
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
-    <PackageReference Include="Functional.Primitives.Extensions" Version="1.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Functional.Common.Extensions" Version="[2.*, 3.0)" />
+    <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
+    <PackageReference Include="Functional.Primitives.Extensions" Version="[2.*, 3.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
   </ItemGroup>
 

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.csproj
@@ -6,11 +6,12 @@
     <Authors>Ryan Marcotte</Authors>
     <Description>Defines a distributed cache using Redis that implements Functional.CQS.AOP.Caching.Infrastructure.IFunctionalCache</Description>
     <Copyright>2019</Copyright>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching redis</PackageTags>
     <Version>3.0.0</Version>
     <PackageReleaseNotes>Updated to Functional 2.0.0</PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/JsonConverters/OptionJsonConverter.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis/JsonConverters/OptionJsonConverter.cs
@@ -36,7 +36,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.DistributedCache.Redis.JsonC
 		{
 			var jsonObject = new JObject();
 			jsonObject.AddFirst(new JProperty(HAS_VALUE_PROPERTY_NAME, value.HasValue()));
-			value.Apply(x => jsonObject.Add(new JProperty(VALUE_PROPERTY_NAME, JToken.FromObject(x))));
+			value.Apply(x => jsonObject.Add(new JProperty(VALUE_PROPERTY_NAME, JToken.FromObject(x))), () => { });
 
 			jsonObject.WriteTo(writer);
 		}

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
-    <PackageReference Include="FakeItEasy" Version="5.0.1" />
-    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="FakeItEasy" Version="5.5.0" />
+    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests/FunctionalMemoryCacheTests.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests/FunctionalMemoryCacheTests.cs
@@ -44,7 +44,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests
 			var result = sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, groupKey, typeof(int), () => KEY_TO_STORE, _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(KEY_TO_STORE));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(KEY_TO_STORE);
 			sut.VerifyOneNewItemHasBeenAdded(_cacheItems, groupKey);
 		}
 
@@ -56,7 +56,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests
 			var result = sut.Get(KEY1, Option.None<string>(), typeof(object), () => _cacheItemLookup[KEY1], _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY1).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(_cacheItemLookup[KEY1]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(_cacheItemLookup[KEY1]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -85,7 +85,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests
 			var result = sut.Get(KEY_NOT_IN_ORIGINAL_CACHE, groupKey, () => itemToStore, _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(itemToStore));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(itemToStore);
 			sut.VerifyOneNewItemHasBeenAdded(_cacheItems, groupKey);
 		}
 
@@ -97,7 +97,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests
 			var result = sut.Get(KEY1, Option.None<string>(), () => _cacheItemLookup[KEY1], _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY1).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(_cacheItemLookup[KEY1]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(_cacheItemLookup[KEY1]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -126,7 +126,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests
 			var result = await sut.GetAsync(KEY_NOT_IN_ORIGINAL_CACHE, groupKey, typeof(int), () => Task.FromResult((object)KEY_TO_STORE), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(KEY_TO_STORE));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(KEY_TO_STORE);
 			sut.VerifyOneNewItemHasBeenAdded(_cacheItems, groupKey);
 		}
 
@@ -138,7 +138,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests
 			var result = await sut.GetAsync(KEY1, Option.None<string>(), typeof(object), () => Task.FromResult(_cacheItemLookup[KEY1]), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY1).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(_cacheItemLookup[KEY1]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(_cacheItemLookup[KEY1]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 
@@ -168,7 +168,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests
 			var result = await sut.GetAsync(KEY_NOT_IN_ORIGINAL_CACHE, groupKey, () => Task.FromResult(itemToStore), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY_NOT_IN_ORIGINAL_CACHE).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(itemToStore));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(itemToStore);
 			sut.VerifyOneNewItemHasBeenAdded(_cacheItems, groupKey);
 		}
 
@@ -182,7 +182,7 @@ namespace Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.Tests
 			var result = await sut.GetAsync(KEY1, groupKey, () => Task.FromResult(_cacheItemLookup[KEY1]), _ => true, TimeSpan.FromMinutes(5));
 
 			sut.Contains(KEY1).Should().BeTrue();
-			result.Should().BeSuccessful(value => value.Should().Be(_cacheItemLookup[KEY1]));
+			result.Should().BeSuccessful().AndSuccessValue.Should().Be(_cacheItemLookup[KEY1]);
 			sut.VerifyNoNewItemsHaveBeenAdded(_cacheItems);
 		}
 

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -6,10 +6,11 @@
     <Description>Defines an in-memory cache that implements Functional.CQS.AOP.Caching.Infrastructure.IFunctionalCache</Description>
     <Copyright>2019</Copyright>
     <Authors>Ryan Marcotte</Authors>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching</PackageTags>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache/Functional.CQS.AOP.Caching.Infrastructure.MemoryCache.csproj
@@ -9,6 +9,7 @@
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching</PackageTags>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -20,10 +21,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Common.Extensions" Version="1.9.0" />
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
-    <PackageReference Include="Functional.Primitives.Extensions" Version="1.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.2.0" />
+    <PackageReference Include="Functional.Common.Extensions" Version="[2.*, 3.0)" />
+    <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
+    <PackageReference Include="Functional.Primitives.Extensions" Version="[2.*, 3.0)" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.Caching.Infrastructure/Functional.CQS.AOP.Caching.Infrastructure.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure/Functional.CQS.AOP.Caching.Infrastructure.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -14,10 +14,11 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Copyright>2019</Copyright>
     <Authors>Ryan Marcotte</Authors>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching</PackageTags>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.Caching.Infrastructure/Functional.CQS.AOP.Caching.Infrastructure.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure/Functional.CQS.AOP.Caching.Infrastructure.csproj
@@ -17,6 +17,7 @@
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching</PackageTags>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -28,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
+	  <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.Caching/Functional.CQS.AOP.Caching.csproj
+++ b/src/Functional.CQS.AOP.Caching/Functional.CQS.AOP.Caching.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -11,7 +11,7 @@
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>functional CQS netstandard netcore caching</PackageTags>
     <Authors>Ryan Marcotte</Authors>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
+	  <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.Caching/Functional.CQS.AOP.Caching.csproj
+++ b/src/Functional.CQS.AOP.Caching/Functional.CQS.AOP.Caching.csproj
@@ -8,10 +8,11 @@
 - IAsyncQueryHandler&lt;TQuery, TResult&gt;</Description>
     <Copyright>2019</Copyright>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageTags>functional CQS netstandard netcore caching</PackageTags>
     <Authors>Ryan Marcotte</Authors>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.IoC.PureDI.Caching.Tests/Functional.CQS.AOP.IoC.PureDI.Caching.Tests.csproj
+++ b/src/Functional.CQS.AOP.IoC.PureDI.Caching.Tests/Functional.CQS.AOP.IoC.PureDI.Caching.Tests.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
-    <PackageReference Include="FakeItEasy" Version="5.0.1" />
-    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="FakeItEasy" Version="5.5.0" />
+    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Functional.CQS.AOP.IoC.PureDI.Caching/Functional.CQS.AOP.IoC.PureDI.Caching.csproj
+++ b/src/Functional.CQS.AOP.IoC.PureDI.Caching/Functional.CQS.AOP.IoC.PureDI.Caching.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -8,10 +8,11 @@
 - IAsyncQueryHandler&lt;TQuery, TResult&gt;</Description>
     <Authors>Ryan Marcotte</Authors>
     <Copyright>2019</Copyright>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching</PackageTags>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.IoC.PureDI.Caching/Functional.CQS.AOP.IoC.PureDI.Caching.csproj
+++ b/src/Functional.CQS.AOP.IoC.PureDI.Caching/Functional.CQS.AOP.IoC.PureDI.Caching.csproj
@@ -11,6 +11,7 @@
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore caching</PackageTags>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -22,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
-    <PackageReference Include="Functional.Primitives.Extensions" Version="1.9.0" />
+    <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
+    <PackageReference Include="Functional.Primitives.Extensions" Version="[2.*, 3.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/AsyncQueryHandlerMetricsCapturingDecoratorForUniversalStrategyTests.cs
+++ b/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/AsyncQueryHandlerMetricsCapturingDecoratorForUniversalStrategyTests.cs
@@ -33,7 +33,7 @@ namespace Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests
 			IUniversalMetricsCapturingStrategy metricsCapturingStrategy)
 		{
 			var query = new DummyQueryReturnsValueType();
-			await Result.Try(async () => await sut.HandleAsync(query));
+			await Result.TryAsync(async () => await sut.HandleAsync(query));
 
 			A.CallTo(() => metricsCapturingStrategy.OnInvocationStart()).MustHaveHappenedOnceExactly();
 			A.CallTo(() => metricsCapturingStrategy.OnInvocationCompletedSuccessfully(A<TimeSpan>._)).MustNotHaveHappened();

--- a/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/AsyncQueryHandlerMetricsCapturingDecoratorTests.cs
+++ b/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/AsyncQueryHandlerMetricsCapturingDecoratorTests.cs
@@ -33,7 +33,7 @@ namespace Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests
 			IMetricsCapturingStrategyForQuery<DummyQueryReturnsValueType, DummyQueryReturnsValueTypeResult> metricsCapturingStrategy)
 		{
 			var query = new DummyQueryReturnsValueType();
-			await Result.Try(async () => await sut.HandleAsync(query));
+			await Result.TryAsync(async () => await sut.HandleAsync(query));
 
 			A.CallTo(() => metricsCapturingStrategy.OnInvocationStart(query)).MustHaveHappenedOnceExactly();
 			A.CallTo(() => metricsCapturingStrategy.OnInvocationCompletedSuccessfully(query, A<DummyQueryReturnsValueTypeResult>._, A<TimeSpan>._)).MustNotHaveHappened();

--- a/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/AsyncResultCommandHandlerMetricsCapturingDecoratorForUniversalStrategyTests.cs
+++ b/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/AsyncResultCommandHandlerMetricsCapturingDecoratorForUniversalStrategyTests.cs
@@ -33,7 +33,7 @@ namespace Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests
 			IUniversalMetricsCapturingStrategy metricsCapturingStrategy)
 		{
 			var command = new DummyAsyncCommandThatSucceeds();
-			await Result.Try(async () => await sut.HandleAsync(command, new CancellationToken()));
+			await Result.TryAsync(async () => await sut.HandleAsync(command, new CancellationToken()));
 
 			A.CallTo(() => metricsCapturingStrategy.OnInvocationStart()).MustHaveHappenedOnceExactly();
 			A.CallTo(() => metricsCapturingStrategy.OnInvocationCompletedSuccessfully(A<TimeSpan>._)).MustNotHaveHappened();
@@ -44,7 +44,7 @@ namespace Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests
 
 		private abstract class AsyncCommandHandlerMetricsCapturingDecoratorTestsArrangementBase : AutoDataAttribute
 		{
-			protected AsyncCommandHandlerMetricsCapturingDecoratorTestsArrangementBase(Func<Task<Result<Unit, DummyAsyncCommandError>>> resultFactory, bool decoratorEnabled)
+			protected AsyncCommandHandlerMetricsCapturingDecoratorTestsArrangementBase(Func<Task<Result<Unit, DummyAsyncCommandError>>> resultFactory)
 				: base(() => new Fixture()
 					.Customize(new AsyncCommandHandlerCustomization(resultFactory))
 					.Customize(new MetricsCapturingStrategyCustomization()))
@@ -56,7 +56,7 @@ namespace Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests
 		private class AsyncCommandHandlerCompletesSuccessfully : AsyncCommandHandlerMetricsCapturingDecoratorTestsArrangementBase
 		{
 			public AsyncCommandHandlerCompletesSuccessfully()
-				: base(() => Task.FromResult(Result.Success<Unit, DummyAsyncCommandError>(Unit.Value)), true)
+				: base(() => Task.FromResult(Result.Success<Unit, DummyAsyncCommandError>(Unit.Value)))
 			{
 			}
 		}
@@ -64,7 +64,7 @@ namespace Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests
 		private class AsyncCommandHandlerThrowsException : AsyncCommandHandlerMetricsCapturingDecoratorTestsArrangementBase
 		{
 			public AsyncCommandHandlerThrowsException()
-				: base(() => Task.FromException<Result<Unit, DummyAsyncCommandError>>(new Exception()), true)
+				: base(() => Task.FromException<Result<Unit, DummyAsyncCommandError>>(new Exception()))
 			{
 			}
 		}

--- a/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/AsyncResultCommandHandlerMetricsCapturingDecoratorTests.cs
+++ b/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/AsyncResultCommandHandlerMetricsCapturingDecoratorTests.cs
@@ -33,7 +33,7 @@ namespace Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests
 			IMetricsCapturingStrategyForCommand<DummyAsyncCommandThatSucceeds, DummyAsyncCommandError> metricsCapturingStrategy)
 		{
 			var command = new DummyAsyncCommandThatSucceeds();
-			await Result.Try(async () => await sut.HandleAsync(command, new CancellationToken()));
+			await Result.TryAsync(async () => await sut.HandleAsync(command, new CancellationToken()));
 
 			A.CallTo(() => metricsCapturingStrategy.OnInvocationStart(command)).MustHaveHappenedOnceExactly();
 			A.CallTo(() => metricsCapturingStrategy.OnInvocationCompletedSuccessfully(command, A<Result<Unit, DummyAsyncCommandError>>._, A<TimeSpan>._)).MustNotHaveHappened();

--- a/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests.csproj
+++ b/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -17,11 +17,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
-    <PackageReference Include="FakeItEasy" Version="5.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="FakeItEasy" Version="5.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.csproj
+++ b/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.csproj
@@ -13,6 +13,7 @@
 - ICommandHandler&lt;TCommand, TError&gt;
 - IAsyncCommandHandler&lt;TCommand, TError&gt;</Description>
     <Copyright>2019</Copyright>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.csproj
+++ b/src/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing/Functional.CQS.AOP.IoC.PureDI.MetricsCapturing.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <Authors>Ryan Marcotte</Authors>
     <PackageTags>functional CQS netstandard netcore metrics</PackageTags>
     <Description>Provides metrics-capturing decorator implementations for Functional.CQS handler implementations:
@@ -14,6 +14,7 @@
 - IAsyncCommandHandler&lt;TCommand, TError&gt;</Description>
     <Copyright>2019</Copyright>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests/Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests/Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests.csproj
@@ -1,18 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFramework>netcoreapp2.2</TargetFramework>
+	  <TargetFramework>netcoreapp3.1</TargetFramework>
 
 	  <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoFixture" Version="4.8.0" />
-		<PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.8.0" />
-		<PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
-		<PackageReference Include="FakeItEasy" Version="5.0.1" />
-		<PackageReference Include="Functional.Primitives.FluentAssertions" Version="1.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+		<PackageReference Include="AutoFixture" Version="4.11.0" />
+		<PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
+		<PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+		<PackageReference Include="FakeItEasy" Version="5.5.0" />
+		<PackageReference Include="Functional.Primitives.FluentAssertions" Version="2.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests/TypeExtensionsTests.cs
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests/TypeExtensionsTests.cs
@@ -3,6 +3,7 @@ using Functional.CQS.AOP.Caching;
 using Functional.CQS.AOP.CommonTestInfrastructure.Caching;
 using Functional.CQS.AOP.CommonTestInfrastructure.Caching.DummyObjects;
 using Functional.CQS.AOP.CommonTestInfrastructure.DummyObjects;
+using Functional.CQS.AOP.IoC.SimpleInjector.Models;
 using Functional.Primitives.FluentAssertions;
 using Xunit;
 
@@ -26,11 +27,12 @@ namespace Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests
 			where TQuery : IQueryParameters<TResult>
 			where TCachingStrategy : IQueryResultCachingStrategy<TQuery, TResult>
 		{
-			typeof(TCachingStrategy).GetGenericParametersForQueryCachingStrategyType().Should().HaveValue(x =>
-			{
-				x.QueryType.Should().Be(typeof(TQuery));
-				x.ResultType.Should().Be(typeof(TResult));
-			});
+			typeof(TCachingStrategy).GetGenericParametersForQueryCachingStrategyType()
+				.Should()
+				.HaveValue()
+				.AndValue
+				.Should()
+				.Match<QueryAndResultType>(x => x.QueryType == typeof(TQuery) && x.ResultType == typeof(TResult));
 		}
 
 		public class WhenCheckingIfTypeIsCachingStrategyForQueryType

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.Caching/Functional.CQS.AOP.IoC.SimpleInjector.Caching.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.Caching/Functional.CQS.AOP.IoC.SimpleInjector.Caching.csproj
@@ -12,13 +12,13 @@ Used with SimpleInjector container.</Description>
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore simpleinjector aop ioc caching</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>2.0.0</Version>
     <Authors>Ryan Marcotte</Authors>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Common.Extensions" Version="1.9.0" />
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
+    <PackageReference Include="Functional.Common.Extensions" Version="[2.*, 3.0)" />
+    <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.Caching/Functional.CQS.AOP.IoC.SimpleInjector.Caching.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.Caching/Functional.CQS.AOP.IoC.SimpleInjector.Caching.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -9,11 +9,12 @@
 
 Used with SimpleInjector container.</Description>
     <Copyright>2019</Copyright>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore simpleinjector aop ioc caching</PackageTags>
     <Version>2.0.0</Version>
     <Authors>Ryan Marcotte</Authors>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.Tests/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.Tests.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.Tests/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -17,12 +17,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.8.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
-    <PackageReference Include="FakeItEasy" Version="5.0.1" />
-    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="AutoFixture" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.11.0" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Include="FakeItEasy" Version="5.5.0" />
+    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.Tests/TypeExtensionsTests.cs
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.Tests/TypeExtensionsTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Functional.CQS.AOP.CommonTestInfrastructure.DummyObjects;
 using Functional.CQS.AOP.CommonTestInfrastructure.MetricsCapturing.DummyObjects;
+using Functional.CQS.AOP.IoC.SimpleInjector.Models;
 using Functional.CQS.AOP.MetricsCapturing;
 using Functional.Primitives.FluentAssertions;
 using Xunit;
@@ -31,22 +32,24 @@ namespace Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.Tests
 			where TQuery : IQueryParameters<TResult>
 			where TMetricsCapturingStrategy : IMetricsCapturingStrategyForQuery<TQuery, TResult>
 		{
-			typeof(TMetricsCapturingStrategy).GetGenericParametersForQueryMetricsCapturingStrategyType().Should().HaveValue(x =>
-			{
-				x.QueryType.Should().Be(typeof(TQuery));
-				x.ResultType.Should().Be(typeof(TResult));
-			});
+			typeof(TMetricsCapturingStrategy).GetGenericParametersForQueryMetricsCapturingStrategyType()
+				.Should()
+				.HaveValue()
+				.AndValue
+				.Should()
+				.Match<QueryAndResultType>(x => x.QueryType == typeof(TQuery) && x.ResultType == typeof(TResult));
 		}
 
 		private static void VerifyCommandMetricsCapturingStrategyType<TCommand, TError, TMetricsCapturingStrategy>()
 			where TCommand : ICommandParameters<TError>
 			where TMetricsCapturingStrategy : IMetricsCapturingStrategyForCommand<TCommand, TError>
 		{
-			typeof(TMetricsCapturingStrategy).GetGenericParametersForCommandMetricsCapturingStrategyType().Should().HaveValue(x =>
-			{
-				x.CommandType.Should().Be(typeof(TCommand));
-				x.ErrorType.Should().Be(typeof(TError));
-			});
+			typeof(TMetricsCapturingStrategy).GetGenericParametersForCommandMetricsCapturingStrategyType()
+				.Should()
+				.HaveValue()
+				.AndValue
+				.Should()
+				.Match<CommandAndErrorType>(x => x.CommandType == typeof(TCommand) && x.ErrorType == typeof(TError));
 		}
 
 		public class WhenCheckingIfTypeIsMetricsCapturingStrategyForQueryType

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -13,9 +13,10 @@ Used with SimpleInjector container.</Description>
     <Authors>Ryan Marcotte</Authors>
     <Copyright>2019</Copyright>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageTags>functional CQS netstandard netcore simpleinjector aop ioc metrics</PackageTags>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing/Functional.CQS.AOP.IoC.SimpleInjector.MetricsCapturing.csproj
@@ -15,6 +15,7 @@ Used with SimpleInjector container.</Description>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>functional CQS netstandard netcore simpleinjector aop ioc metrics</PackageTags>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,8 +27,8 @@ Used with SimpleInjector container.</Description>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Common.Extensions" Version="1.9.0" />
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
+    <PackageReference Include="Functional.Common.Extensions" Version="[2.*, 3.0)" />
+    <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.Tests/Functional.CQS.AOP.IoC.SimpleInjector.Tests.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.Tests/Functional.CQS.AOP.IoC.SimpleInjector.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector.Tests/TypeExtensionsTests.cs
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector.Tests/TypeExtensionsTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Functional.CQS.AOP.CommonTestInfrastructure.DummyObjects;
+using Functional.CQS.AOP.IoC.SimpleInjector.Models;
 using Functional.Primitives.FluentAssertions;
 using Xunit;
 
@@ -8,37 +9,43 @@ namespace Functional.CQS.AOP.IoC.SimpleInjector.Tests
 	public class TypeExtensionsTests
 	{
 		[Fact]
-		public void ShouldReturnExpectedQueryAndResultTypeForDummyQueryReturnsValueTypeHandler() => VerifyQueryHandlerType<DummyQueryReturnsValueType, DummyQueryReturnsValueTypeResult, DummyQueryReturnsValueTypeHandler>();
+		public void ShouldReturnExpectedQueryAndResultTypeForDummyQueryReturnsValueTypeHandler()
+			=> VerifyQueryHandlerType<DummyQueryReturnsValueType, DummyQueryReturnsValueTypeResult, DummyQueryReturnsValueTypeHandler>();
 
 		[Fact]
-		public void ShouldReturnExpectedQueryAndResultTypeForDummyQueryReturnsReferenceTypeHandler() => VerifyQueryHandlerType<DummyQueryReturnsReferenceType, DummyQueryReturnsReferenceTypeResult, DummyQueryReturnsReferenceTypeHandler>();
+		public void ShouldReturnExpectedQueryAndResultTypeForDummyQueryReturnsReferenceTypeHandler()
+			=> VerifyQueryHandlerType<DummyQueryReturnsReferenceType, DummyQueryReturnsReferenceTypeResult, DummyQueryReturnsReferenceTypeHandler>();
 
 		[Fact]
-		public void ShouldReturnExpectedQueryAndResultTypeForDummyAsyncQueryReturnsValueTypeHandler() => VerifyAsyncQueryHandlerType<DummyAsyncQueryReturnsValueType, DummyAsyncQueryReturnsValueTypeResult, DummyAsyncQueryReturnsValueTypeHandler>();
+		public void ShouldReturnExpectedQueryAndResultTypeForDummyAsyncQueryReturnsValueTypeHandler()
+			=> VerifyAsyncQueryHandlerType<DummyAsyncQueryReturnsValueType, DummyAsyncQueryReturnsValueTypeResult, DummyAsyncQueryReturnsValueTypeHandler>();
 
 		[Fact]
-		public void ShouldReturnExpectedQueryAndResultTypeForDummyAsyncQueryReturnsReferenceTypeHandler() => VerifyAsyncQueryHandlerType<DummyAsyncQueryReturnsReferenceType, DummyAsyncQueryReturnsReferenceTypeResult, DummyAsyncQueryReturnsReferenceTypeHandler>();
+		public void ShouldReturnExpectedQueryAndResultTypeForDummyAsyncQueryReturnsReferenceTypeHandler()
+			=> VerifyAsyncQueryHandlerType<DummyAsyncQueryReturnsReferenceType, DummyAsyncQueryReturnsReferenceTypeResult, DummyAsyncQueryReturnsReferenceTypeHandler>();
 
 		private static void VerifyQueryHandlerType<TQuery, TResult, TQueryHandler>()
 			where TQuery : IQueryParameters<TResult>
 			where TQueryHandler : IQueryHandler<TQuery, TResult>
 		{
-			typeof(TQueryHandler).GetGenericParametersForQueryHandlerType().Should().HaveValue(x =>
-			{
-				x.QueryType.Should().Be(typeof(TQuery));
-				x.ResultType.Should().Be(typeof(TResult));
-			});
+			typeof(TQueryHandler).GetGenericParametersForQueryHandlerType()
+				.Should()
+				.HaveValue()
+				.AndValue
+				.Should()
+				.Match<QueryAndResultType>(x => x.QueryType == typeof(TQuery) && x.ResultType == typeof(TResult));
 		}
 
 		private static void VerifyAsyncQueryHandlerType<TQuery, TResult, TQueryHandler>()
 			where TQuery : IQueryParameters<TResult>
 			where TQueryHandler : IAsyncQueryHandler<TQuery, TResult>
 		{
-			typeof(TQueryHandler).GetGenericParametersForQueryHandlerType().Should().HaveValue(x =>
-			{
-				x.QueryType.Should().Be(typeof(TQuery));
-				x.ResultType.Should().Be(typeof(TResult));
-			});
+			typeof(TQueryHandler).GetGenericParametersForQueryHandlerType()
+				.Should()
+				.HaveValue()
+				.AndValue
+				.Should()
+				.Match<QueryAndResultType>(x => x.QueryType == typeof(TQuery) && x.ResultType == typeof(TResult));
 		}
 	}
 }

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector/Functional.CQS.AOP.IoC.SimpleInjector.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector/Functional.CQS.AOP.IoC.SimpleInjector.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -10,12 +10,13 @@
 - Functional.CQS.IAsyncCommandHandler&lt;TCommand, TError&gt;</Description>
     <RepositoryUrl></RepositoryUrl>
     <Copyright>2019</Copyright>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
     <PackageTags>functional CQS netstandard netcore simpleinjector aop ioc</PackageTags>
     <Authors>Ryan Marcotte</Authors>
     <Company>Ryan Marcotte</Company>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.IoC.SimpleInjector/Functional.CQS.AOP.IoC.SimpleInjector.csproj
+++ b/src/Functional.CQS.AOP.IoC.SimpleInjector/Functional.CQS.AOP.IoC.SimpleInjector.csproj
@@ -15,6 +15,7 @@
     <PackageTags>functional CQS netstandard netcore simpleinjector aop ioc</PackageTags>
     <Authors>Ryan Marcotte</Authors>
     <Company>Ryan Marcotte</Company>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
-    <PackageReference Include="Functional.Primitives.Extensions" Version="1.9.0" />
-    <PackageReference Include="SimpleInjector" Version="4.4.3" />
+    <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
+    <PackageReference Include="Functional.Primitives.Extensions" Version="[2.*, 3.0)" />
+    <PackageReference Include="SimpleInjector" Version="4.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Functional.CQS.AOP.MetricsCapturing/Functional.CQS.AOP.MetricsCapturing.csproj
+++ b/src/Functional.CQS.AOP.MetricsCapturing/Functional.CQS.AOP.MetricsCapturing.csproj
@@ -12,6 +12,7 @@
 - IMetricsCapturingStrategyForCommand&lt;TCommand, TError&gt;</Description>
     <Copyright>2019</Copyright>
     <PackageTags>functional CQS netstandard netcore metrics</PackageTags>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS.AOP.MetricsCapturing/Functional.CQS.AOP.MetricsCapturing.csproj
+++ b/src/Functional.CQS.AOP.MetricsCapturing/Functional.CQS.AOP.MetricsCapturing.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <Authors>Ryan Marcotte</Authors>
     <Description>Defines contracts for metrics-capturing components to be used alongside Functional.CQS handler implementations:
 - IUniversalMetricsCapturingStrategy
@@ -13,6 +13,7 @@
     <Copyright>2019</Copyright>
     <PackageTags>functional CQS netstandard netcore metrics</PackageTags>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS/Functional.CQS.csproj
+++ b/src/Functional.CQS/Functional.CQS.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/RyanMarcotte/Functional.CQS/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <Copyright>2019</Copyright>
     <Authors>Ryan Marcotte</Authors>
     <Description>Provides CQS-style generic contracts built over Functional.Primitives
@@ -14,6 +14,7 @@
 - IAsyncCommandHandler&lt;TCommand, TError&gt; returning Task&lt;Result&lt;Unit, TError&gt;&gt;</Description>
     <PackageTags>functional CQS netstandard netcore</PackageTags>
     <Version>2.0.0</Version>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Functional.CQS/Functional.CQS.csproj
+++ b/src/Functional.CQS/Functional.CQS.csproj
@@ -13,6 +13,7 @@
 - ICommandHandler&lt;TCommand, TError&gt; returning Result&lt;Unit, TError&gt;
 - IAsyncCommandHandler&lt;TCommand, TError&gt; returning Task&lt;Result&lt;Unit, TError&gt;&gt;</Description>
     <PackageTags>functional CQS netstandard netcore</PackageTags>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -24,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Functional.Primitives" Version="1.9.0" />
+    <PackageReference Include="Functional.Primitives" Version="[2.*, 3.0)" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Not expecting a review on this one since there are no new features included as part of these changes.
- Updates all projects to use `Functional 2.0.1` (and other latest packages).
- Updates projects to .NET Core 3.1.