### PR TITLE
add null cache

### DIFF
--- a/src/Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests/Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests/Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Functional.Primitives.FluentAssertions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Functional.CQS.AOP.Caching.Infrastructure.NullCache\Functional.CQS.AOP.Caching.Infrastructure.NullCache.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests/FunctionalNullCacheTests.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests/FunctionalNullCacheTests.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Functional.Primitives.FluentAssertions;
+using Xunit;
+
+namespace Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests
+{
+	public class FunctionalNullCacheTests
+	{
+		[Fact]
+		public void AlwaysExecutesTypedDelegate()
+		{
+			const string VALUE = "1337";
+			int count = 0;
+
+			string DataRetriever()
+			{
+				++count;
+				return VALUE;
+			}
+
+			var sut = new FunctionalNullCache();
+			var value1 = sut.Get("key", Option.None<string>(), DataRetriever, i => true, TimeSpan.FromSeconds(5));
+			var value2 = sut.Get("key", Option.None<string>(), DataRetriever, i => true, TimeSpan.FromSeconds(5));
+
+			value1.Should().BeSuccessful().AndSuccessValue.Should().Be(VALUE);
+			value2.Should().BeSuccessful().AndSuccessValue.Should().Be(VALUE);
+
+			count.Should().Be(2);
+		}
+
+		[Fact]
+		public void AlwaysExecutesUntypedDelegate()
+		{
+			const string VALUE = "1337";
+			int count = 0;
+
+			object DataRetriever()
+			{
+				++count;
+				return VALUE;
+			}
+
+			var sut = new FunctionalNullCache();
+			var value1 = sut.Get("key", Option.None<string>(), typeof(string), DataRetriever, i => true, TimeSpan.FromSeconds(5));
+			var value2 = sut.Get("key", Option.None<string>(), typeof(string), DataRetriever, i => true, TimeSpan.FromSeconds(5));
+
+			value1.Should().BeSuccessful().AndSuccessValue.Should().Be(VALUE);
+			value2.Should().BeSuccessful().AndSuccessValue.Should().Be(VALUE);
+
+			count.Should().Be(2);
+		}
+
+		[Fact]
+		public async Task AlwaysExecutesTypedAsyncDelegate()
+		{
+			const string VALUE = "1337";
+			int count = 0;
+
+			Task<string> DataRetriever()
+			{
+				++count;
+				return Task.FromResult(VALUE);
+			}
+
+			var sut = new FunctionalNullCache();
+			var value1 = await sut.GetAsync("key", Option.None<string>(), DataRetriever, i => true, TimeSpan.FromSeconds(5));
+			var value2 = await sut.GetAsync("key", Option.None<string>(), DataRetriever, i => true, TimeSpan.FromSeconds(5));
+
+			value1.Should().BeSuccessful().AndSuccessValue.Should().Be(VALUE);
+			value2.Should().BeSuccessful().AndSuccessValue.Should().Be(VALUE);
+
+			count.Should().Be(2);
+		}
+
+		[Fact]
+		public async Task AlwaysExecutesUntypedAsyncDelegate()
+		{
+			const string VALUE = "1337";
+			int count = 0;
+
+			Task<object> DataRetriever()
+			{
+				++count;
+				return Task.FromResult<object>(VALUE);
+			}
+
+			var sut = new FunctionalNullCache();
+			var value1 = await sut.GetAsync("key", Option.None<string>(), typeof(string), DataRetriever, i => true, TimeSpan.FromSeconds(5));
+			var value2 = await sut.GetAsync("key", Option.None<string>(), typeof(string), DataRetriever, i => true, TimeSpan.FromSeconds(5));
+
+			value1.Should().BeSuccessful().AndSuccessValue.Should().Be(VALUE);
+			value2.Should().BeSuccessful().AndSuccessValue.Should().Be(VALUE);
+
+			count.Should().Be(2);
+		}
+	}
+}

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.NullCache/Functional.CQS.AOP.Caching.Infrastructure.NullCache.csproj
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.NullCache/Functional.CQS.AOP.Caching.Infrastructure.NullCache.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/RyanMarcotte/Functional.CQS</PackageProjectUrl>
+    <PackageTags>functional CQS netstandard netcore caching</PackageTags>
+    <Description>Defines FunctionalNullCache, a null object that implements Functional.CQS.AOP.Caching.Infrastructure.IFunctionalCache</Description>
+    <Copyright>2019</Copyright>
+    <Authors>Ryan Marcotte</Authors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>bin\Debug</OutputPath>
+    <DocumentationFile>bin\Debug\Functional.CQS.AOP.Caching.Infrastructure.NullCache.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release</OutputPath>
+    <DocumentationFile>bin\Release\Functional.CQS.AOP.Caching.Infrastructure.NullCache.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Functional.CQS.AOP.Caching.Infrastructure\Functional.CQS.AOP.Caching.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Functional.CQS.AOP.Caching.Infrastructure.NullCache/FunctionalNullCache.cs
+++ b/src/Functional.CQS.AOP.Caching.Infrastructure.NullCache/FunctionalNullCache.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Functional.CQS.AOP.Caching.Infrastructure.NullCache
+{
+	/// <summary>
+	/// Implements the null object pattern for the <see cref="IFunctionalCache"/>.
+	/// </summary>
+	public class FunctionalNullCache : IFunctionalCache
+	{
+		/// <summary>
+		/// Does nothing.
+		/// </summary>
+		/// <typeparam name="T">The type of item to add.</typeparam>
+		/// <param name="key">The key used to uniquely identify the cached item.</param>
+		/// <param name="groupKey">The optional key used for identifying the cached item as part of a group.</param>
+		/// <param name="item">The item to add.</param>
+		/// <param name="timeToLive">The amount of time to keep the item in the cache.</param>
+		public Result<Unit, Exception> Add<T>(string key, Option<string> groupKey, T item, TimeSpan timeToLive)
+		{
+			return Result.Unit<Exception>();
+		}
+
+		/// <summary>
+		/// Invokes <paramref name="dataRetriever"/> to retrieve the item.
+		/// </summary>
+		/// <typeparam name="T">The type of item to retrieve.</typeparam>
+		/// <param name="key">The key used to uniquely identify the cached item.</param>
+		/// <param name="groupKey">The optional key used for identifying the cached item as part of a group.</param>
+		/// <param name="dataRetriever">If the item does not exist in the cache, this function is called to generate the item and then add it to the cache.</param>
+		/// <param name="shouldCacheData">If the item does not exist in the cache, this function is called after the item is retrieved to determine if it should be added to the cache.</param>
+		/// <param name="timeToLive">The amount of time to keep the item in the cache.</param>
+		/// <returns></returns>
+		public Result<T, Exception> Get<T>(string key, Option<string> groupKey, Func<T> dataRetriever, Func<T, bool> shouldCacheData, TimeSpan timeToLive) where T : class
+		{
+			return Result.Success<T, Exception>(dataRetriever.Invoke());
+		}
+
+		/// <summary>
+		/// Invokes <paramref name="dataRetriever"/> to retrieve the item.
+		/// </summary>
+		/// <param name="key">The key used to uniquely identify the cached item.</param>
+		/// <param name="groupKey">The optional key used for identifying the cached item as part of a group.</param>
+		/// <param name="type">The type of item to retrieve.</param>
+		/// <param name="dataRetriever">If the item does not exist in the cache, this function is called to generate the item and then add it to the cache.</param>
+		/// <param name="shouldCacheData">If the item does not exist in the cache, this function is called after the item is retrieved to determine if it should be added to the cache.</param>
+		/// <param name="timeToLive">The amount of time to keep the item in the cache.</param>
+		/// <returns></returns>
+		public Result<object, Exception> Get(string key, Option<string> groupKey, Type type, Func<object> dataRetriever, Func<object, bool> shouldCacheData, TimeSpan timeToLive)
+		{
+			return Result.Success<object, Exception>(dataRetriever.Invoke());
+		}
+
+		/// <summary>
+		/// Invokes <paramref name="dataRetriever"/> to retrieve the item.
+		/// </summary>
+		/// <typeparam name="T">The type of item to retrieve.</typeparam>
+		/// <param name="key">The key used to uniquely identify the cached item.</param>
+		/// <param name="groupKey">The optional key used for identifying the cached item as part of a group.  If null, the cached item will not belong to a group.</param>
+		/// <param name="dataRetriever">If the item does not exist in the cache, this function is called to generate the item and then add it to the cache.</param>
+		/// <param name="shouldCacheData">If the item does not exist in the cache, this function is called after the item is retrieved to determine if it should be added to the cache.</param>
+		/// <param name="timeToLive">The amount of time to keep the item in the cache.</param>
+		/// <returns></returns>
+		public async Task<Result<T, Exception>> GetAsync<T>(string key, Option<string> groupKey, Func<Task<T>> dataRetriever, Func<T, bool> shouldCacheData, TimeSpan timeToLive) where T : class
+		{
+			return Result.Success<T, Exception>(await dataRetriever.Invoke());
+		}
+
+		/// <summary>
+		/// Invokes <paramref name="dataRetriever"/> to retrieve the item.
+		/// </summary>
+		/// <param name="key">The key used to uniquely identify the cached item.</param>
+		/// <param name="groupKey">The optional key used for identifying the cached item as part of a group.  If null, the cached item will not belong to a group.</param>
+		/// <param name="type">The type of item to retrieve.</param>
+		/// <param name="dataRetriever">If the item does not exist in the cache, this function is called to generate the item and then add it to the cache.</param>
+		/// <param name="shouldCacheData">If the item does not exist in the cache, this function is called after the item is retrieved to determine if it should be added to the cache.</param>
+		/// <param name="timeToLive">The amount of time to keep the item in the cache.</param>
+		/// <returns></returns>
+		public async Task<Result<object, Exception>> GetAsync(string key, Option<string> groupKey, Type type, Func<Task<object>> dataRetriever, Func<object, bool> shouldCacheData, TimeSpan timeToLive)
+		{
+			return Result.Success<object, Exception>(await dataRetriever.Invoke());
+		}
+
+		/// <summary>
+		/// Does nothing.
+		/// </summary>
+		/// <param name="key">The key used to uniquely identify the cached item.</param>
+		public Result<Unit, Exception> Remove(string key)
+		{
+			return Result.Unit<Exception>();
+		}
+
+		/// <summary>
+		/// Does nothing.
+		/// </summary>
+		/// <param name="groupKey">The key used to identify a group of cached items.</param>
+		public Result<Unit, Exception> RemoveGroup(string groupKey)
+		{
+			return Result.Unit<Exception>();
+		}
+
+		/// <summary>
+		/// Does nothing.
+		/// </summary>
+		public Result<Unit, Exception> Clear()
+		{
+			return Result.Unit<Exception>();
+		}
+	}
+}

--- a/src/Functional.CQS.sln
+++ b/src/Functional.CQS.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.168
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29728.190
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functional.CQS", "Functional.CQS\Functional.CQS.csproj", "{7C8AA96C-DEDB-48A3-95F0-7855C26C8E83}"
 EndProject
@@ -50,6 +50,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests", "Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests\Functional.CQS.AOP.IoC.SimpleInjector.Caching.Tests.csproj", "{C3BA79AE-E134-45BD-85FD-3D27853284AF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Common", "Common", "{B236E576-7D86-4852-B44A-057FA63E0237}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Functional.CQS.AOP.Caching.Infrastructure.NullCache", "Functional.CQS.AOP.Caching.Infrastructure.NullCache\Functional.CQS.AOP.Caching.Infrastructure.NullCache.csproj", "{F9FA20C7-3BF9-4D59-AC6A-7F314666B590}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests", "Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests\Functional.CQS.AOP.Caching.Infrastructure.NullCache.Tests.csproj", "{0D264039-CC8B-4924-A674-BE15C6439A24}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -141,6 +145,14 @@ Global
 		{C3BA79AE-E134-45BD-85FD-3D27853284AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C3BA79AE-E134-45BD-85FD-3D27853284AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C3BA79AE-E134-45BD-85FD-3D27853284AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F9FA20C7-3BF9-4D59-AC6A-7F314666B590}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F9FA20C7-3BF9-4D59-AC6A-7F314666B590}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F9FA20C7-3BF9-4D59-AC6A-7F314666B590}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F9FA20C7-3BF9-4D59-AC6A-7F314666B590}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D264039-CC8B-4924-A674-BE15C6439A24}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D264039-CC8B-4924-A674-BE15C6439A24}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D264039-CC8B-4924-A674-BE15C6439A24}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D264039-CC8B-4924-A674-BE15C6439A24}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
In another project, I am using the Redis cache implementation provided by this library.  In scenarios where the Redis cache is not up (perhaps because I forgot to start up a Redis instance on my development machine?), I would rather have the system be operational without caching instead of having system startup fail entirely.  This requires a cache implementation that does nothing (the [null object pattern](https://en.wikipedia.org/wiki/Null_object_pattern)).  I am adding `FunctionalNullCache` to the library suite because others may also find it useful.